### PR TITLE
feat(license): added MIT license to the repo

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 Plus Five Five, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/with-attachments/package.json
+++ b/with-attachments/package.json
@@ -2,6 +2,7 @@
   "name": "with-attachments",
   "description": "Resend with attachments",
   "version": "0.0.1",
+  "license": "MIT",
   "scripts": {
     "build": "next build",
     "dev": "next dev",

--- a/with-domains/package.json
+++ b/with-domains/package.json
@@ -2,6 +2,7 @@
   "name": "with-domains",
   "description": "Resend with Domains",
   "version": "0.0.1",
+  "license": "MIT",
   "scripts": {
     "build": "next build",
     "dev": "next dev",

--- a/with-nextauth/package.json
+++ b/with-nextauth/package.json
@@ -2,6 +2,7 @@
   "name": "with-nextauth",
   "description": "Resend with nextauth",
   "version": "0.0.1",
+  "license": "MIT",
   "scripts": {
     "build": "next build",
     "dev": "next dev",

--- a/with-webhooks/package.json
+++ b/with-webhooks/package.json
@@ -2,6 +2,7 @@
   "name": "with-webhooks",
   "description": "Resend with webhooks",
   "version": "0.0.1",
+  "license": "MIT",
   "scripts": {
     "build": "next build",
     "dev": "next dev",


### PR DESCRIPTION
## Description
- Added a license to the project

## Why ?
- Setting up the examples locally shows a warning, 'no license found' (**Image below**)
<img width="411" alt="Screenshot 2023-07-12 at 22 56 45" src="https://github.com/resendlabs/resend-examples/assets/67395687/f2301da2-df90-42cd-a72a-784493b46e26">
