### PR TITLE
fix(with-attachments): Add path to attachments example in README

### DIFF
--- a/with-attachments/readme.md
+++ b/with-attachments/readme.md
@@ -34,6 +34,7 @@ const data = await resend.emails.send({
   attachments: [
     {
       content: invoiceBuffer,
+      path: 'path/to/file/invoice.pdf',
       filename: 'invoice.pdf',
     },
   ],


### PR DESCRIPTION
## Description

Updated the README file for `with-attachments`. Added the `path` field to the attachments in the examples for uniformity with the code in `pages/api/send.ts`